### PR TITLE
[ISSUE-8041] Add requiresMainQueueSetup

### DIFF
--- a/RCTPrivacySnapshot/RCTPrivacySnapshot.m
+++ b/RCTPrivacySnapshot/RCTPrivacySnapshot.m
@@ -14,6 +14,11 @@
     UIImageView *obfuscatingView;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_MODULE();
 
 #pragma mark - Lifecycle
@@ -38,14 +43,14 @@ RCT_EXPORT_MODULE();
     if (self->enabled) {
         UIWindow    *keyWindow = [UIApplication sharedApplication].keyWindow;
         UIImageView *blurredScreenImageView = [[UIImageView alloc] initWithFrame:keyWindow.bounds];
-        
+
         UIGraphicsBeginImageContext(keyWindow.bounds.size);
         [keyWindow drawViewHierarchyInRect:keyWindow.frame afterScreenUpdates:NO];
         UIImage *viewImage = UIGraphicsGetImageFromCurrentImageContext();
         UIGraphicsEndImageContext();
-        
+
         blurredScreenImageView.image = [viewImage applyLightEffect];
-        
+
         self->obfuscatingView = blurredScreenImageView;
         [[UIApplication sharedApplication].keyWindow addSubview:self->obfuscatingView];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-privacy-snapshot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Obscure passwords and other sensitive personal information when a react-native app transitions to the background",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
JIRA: https://insightsquared.atlassian.net/browse/ISSUE-8041

This updates the package to use `requiresMainQueueSetup`, fixing the error we've been seeing.

Using the existing package:

![image](https://user-images.githubusercontent.com/17487532/75368345-95804300-588f-11ea-8321-14f9a7e419f6.png)

Using this branch of the forked package:
- Updated `package.json` with `"react-native-privacy-snapshot": "github:olono/react-native-privacy-snapshot#issue-8041"`

![image](https://user-images.githubusercontent.com/17487532/75368376-a335c880-588f-11ea-96d1-bdd104c3581e.png)

PR into mobile-client to use this package to follow.