### PR TITLE
[ISSUE-8041] Update name so we can publish package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@olono/react-native-privacy-snapshot",
+  "name": "@olono/olono-react-native-privacy-snapshot",
   "version": "1.0.1",
   "description": "Obscure passwords and other sensitive personal information when a react-native app transitions to the background",
   "main": "index.js",


### PR DESCRIPTION
There's an existing package called `react-native-privacy-snapshot` so, even with the scoping, we can't publish one under that name.